### PR TITLE
[云原生 - 2. 服务治理云原生架构] 作业一：补充 microsphere-etcd-spring-cloud 中的 ReactiveDiscoveryClient 实现

### DIFF
--- a/microsphere-etcd-dependencies/pom.xml
+++ b/microsphere-etcd-dependencies/pom.xml
@@ -26,7 +26,6 @@
                 <artifactId>microsphere-etcd-spring-cloud</artifactId>
                 <version>${revision}</version>
             </dependency>
-
         </dependencies>
     </dependencyManagement>
 </project>

--- a/microsphere-etcd-parent/pom.xml
+++ b/microsphere-etcd-parent/pom.xml
@@ -27,6 +27,7 @@
         <spring-cloud-dependencies.version>2021.0.7</spring-cloud-dependencies.version>
         <!-- Third-party versions -->
         <jetcd.version>0.7.5</jetcd.version>
+        <reactor.version>3.3.15.RELEASE</reactor.version>
     </properties>
 
     <dependencyManagement>
@@ -93,6 +94,12 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- reactor -->
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-core</artifactId>
+                <version>${reactor.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/microsphere-etcd-spring-cloud/pom.xml
+++ b/microsphere-etcd-spring-cloud/pom.xml
@@ -70,6 +70,12 @@
             <artifactId>jetcd-core</artifactId>
         </dependency>
 
+        <!-- reactor -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+        </dependency>
+
         <!-- Testing -->
 
         <dependency>

--- a/microsphere-etcd-spring-cloud/src/main/java/io/microsphere/etcd/spring/cloud/client/discovery/EtcdClientAdapter.java
+++ b/microsphere-etcd-spring-cloud/src/main/java/io/microsphere/etcd/spring/cloud/client/discovery/EtcdClientAdapter.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.microsphere.etcd.spring.cloud.client.discovery;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.Watch;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.options.GetOption;
+import io.etcd.jetcd.options.WatchOption;
+import org.springframework.cloud.client.DefaultServiceInstance;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * Adapter {@link Client} for etcd
+ *
+ * @author <a href="mailto:walklown@gmail.com">Walklown</a>
+ * @see Client
+ * @since 1.0.0
+ */
+public class EtcdClientAdapter implements Closeable {
+
+    private final KV kv;
+
+    private final Watch watch;
+
+    private final ObjectMapper objectMapper;
+
+    public EtcdClientAdapter(Client client, ObjectMapper objectMapper) {
+        this.kv = client.getKVClient();
+        this.watch = client.getWatchClient();
+        this.objectMapper = objectMapper;
+    }
+
+    public List<KeyValue> getKeyValues(ByteSequence key, boolean isKeysOnly) {
+        GetOption.Builder builder = GetOption.newBuilder()
+                .withKeysOnly(isKeysOnly)
+                .isPrefix(true);
+        CompletableFuture<GetResponse> getResponseFuture = kv.get(key, builder.build());
+        List<KeyValue> keyValues = emptyList();
+        try {
+            GetResponse response = getResponseFuture.get(1, TimeUnit.SECONDS);
+            keyValues = response.getKvs();
+        } catch (Throwable e) {
+        }
+        return keyValues;
+    }
+
+    public DefaultServiceInstance deserializeValue(ByteSequence value) {
+        byte[] content = value.getBytes();
+        DefaultServiceInstance serviceInstance = null;
+        try {
+            // FIXME Bug on Jackson
+            serviceInstance = objectMapper.readValue(content, DefaultServiceInstance.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return serviceInstance;
+    }
+
+    public void watchService(ByteSequence key, Watch.Listener listener) {
+        WatchOption.Builder builder = WatchOption.newBuilder().withPrevKV(true).isPrefix(true);
+        watch.watch(key, builder.build(), listener);
+    }
+
+    @Override
+    public void close() {
+        this.kv.close();
+    }
+}

--- a/microsphere-etcd-spring-cloud/src/main/java/io/microsphere/etcd/spring/cloud/client/discovery/ServiceInstancesCache.java
+++ b/microsphere-etcd-spring-cloud/src/main/java/io/microsphere/etcd/spring/cloud/client/discovery/ServiceInstancesCache.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.microsphere.etcd.spring.cloud.client.discovery;
+
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.Watch;
+import io.etcd.jetcd.watch.WatchEvent;
+import io.etcd.jetcd.watch.WatchResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+import static io.microsphere.etcd.spring.cloud.client.util.KVClientUtils.buildInstanceId;
+import static io.microsphere.etcd.spring.cloud.client.util.KVClientUtils.buildServicePath;
+import static io.microsphere.etcd.spring.cloud.client.util.KVClientUtils.toByteSequence;
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * Cache {@link ServiceInstance} for {@link EtcdDiscoveryClient} and {@link EtcdReactiveDiscoveryClient}
+ *
+ * @author <a href="mailto:walklown@gmail.com">Walklown</a>
+ * @see EtcdDiscoveryClient
+ * @see EtcdReactiveDiscoveryClient
+ * @since 1.0.0
+ */
+public class ServiceInstancesCache {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServiceInstancesCache.class);
+
+    private final ConcurrentMap<String, List<ServiceInstance>> serviceInstancesCache;
+
+    private final String rootPath;
+
+    private final EtcdClientAdapter etcdClientAdapter;
+
+    public ServiceInstancesCache(String rootPath, EtcdClientAdapter etcdClientAdapter) {
+        this.serviceInstancesCache = new ConcurrentHashMap<>(16);
+        this.rootPath = rootPath;
+        this.etcdClientAdapter = etcdClientAdapter;
+    }
+
+    public List<ServiceInstance> getValue(String serviceId) {
+        // Sync Load in the first time
+        // Cache if hit
+        // Async update cache based on Watch Events
+        List<ServiceInstance> sourceInstanceList = serviceInstancesCache.computeIfAbsent(serviceId, key -> {
+            String servicePath = buildServicePath(rootPath, serviceId);
+            List<ServiceInstance> serviceInstanceList = doGetInstances(servicePath);
+            watchService(servicePath, serviceId);
+            return serviceInstanceList;
+        });
+        return unmodifiableList(sourceInstanceList);
+    }
+
+    protected List<ServiceInstance> doGetInstances(String servicePath) {
+        ByteSequence key = toByteSequence(servicePath);
+        List<KeyValue> keyValues = etcdClientAdapter.getKeyValues(key, false);
+        return keyValues.stream()
+                .map(KeyValue::getValue)
+                .map(etcdClientAdapter::deserializeValue)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    private void watchService(String servicePath, String serviceId) {
+        ByteSequence key = toByteSequence(servicePath);
+        etcdClientAdapter.watchService(key, new ServiceInstanceEventListener(serviceId));
+    }
+
+    public class ServiceInstanceEventListener implements Watch.Listener {
+
+        private final String serviceId;
+
+        public ServiceInstanceEventListener(String serviceId) {
+            this.serviceId = serviceId;
+        }
+
+        @Override
+        public void onNext(WatchResponse response) {
+            response.getEvents().forEach(event -> {
+                logger.info("WatchEvent : " + event);
+                WatchEvent.EventType eventType = event.getEventType();
+                switch (eventType) {
+                    case PUT:
+                        addOrUpdateServiceInstance(event, serviceId);
+                        break;
+                    case DELETE:
+                        deleteServiceInstance(event, serviceId);
+                        break;
+                    default:
+                        logger.warn("Unknown Event Type : " + eventType);
+                        break;
+                }
+            });
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+
+        }
+
+        @Override
+        public void onCompleted() {
+            logger.info("onCompleted()");
+        }
+
+        private void addOrUpdateServiceInstance(WatchEvent event, String serviceId) {
+            KeyValue currentKeyValue = event.getKeyValue();
+            ByteSequence key = currentKeyValue.getKey();
+            ByteSequence value = currentKeyValue.getValue();
+            String instanceId = buildInstanceId(rootPath, serviceId, key.toString());
+            ServiceInstance serviceInstance = etcdClientAdapter.deserializeValue(value);
+            synchronized (this) { // TODO: Optimization Lock
+                List<ServiceInstance> serviceInstances = serviceInstancesCache.computeIfAbsent(serviceId, i -> new LinkedList<>());
+
+                if (isAddServiceInstance(event)) { // Add
+                    serviceInstances.add(serviceInstance);
+                } else { // Update
+                    int index = -1;
+                    int size = serviceInstances.size();
+                    if (size > 0) {
+                        serviceInstances.add(serviceInstance);
+                        for (int i = 0; i < size; i++) {
+                            ServiceInstance previousServiceInstance = serviceInstances.get(i);
+                            if (instanceId.equals(previousServiceInstance.getInstanceId())) {
+                                index = i;
+                                break;
+                            }
+                        }
+                        if (index > -1) {
+                            serviceInstances.set(index, serviceInstance);
+                            return;
+                        }
+                    }
+                    serviceInstances.add(serviceInstance);
+                }
+            }
+
+        }
+
+        private void deleteServiceInstance(WatchEvent event, String serviceId) {
+            KeyValue currentKeyValue = event.getKeyValue();
+            String instanceId = buildInstanceId(rootPath, serviceId, currentKeyValue.getKey().toString());
+            synchronized (this) { // TODO: Optimization Lock
+                List<ServiceInstance> serviceInstances = serviceInstancesCache.get(serviceId);
+                if (!CollectionUtils.isEmpty(serviceInstances)) {
+                    Iterator<ServiceInstance> iterator = serviceInstances.iterator();
+                    while (iterator.hasNext()) {
+                        ServiceInstance serviceInstance = iterator.next();
+                        if (instanceId.equals(serviceInstance.getInstanceId())) {
+                            iterator.remove();
+                        }
+                    }
+                }
+            }
+        }
+
+        private boolean isAddServiceInstance(WatchEvent event) {
+            KeyValue previousKeyValue = event.getPrevKV();
+            return previousKeyValue == null || previousKeyValue.getKey().isEmpty();
+        }
+    }
+}

--- a/microsphere-etcd-spring-cloud/src/main/java/io/microsphere/etcd/spring/cloud/client/discovery/autoconfigure/EtcdDiscoveryAutoConfiguration.java
+++ b/microsphere-etcd-spring-cloud/src/main/java/io/microsphere/etcd/spring/cloud/client/discovery/autoconfigure/EtcdDiscoveryAutoConfiguration.java
@@ -21,9 +21,13 @@ import io.etcd.jetcd.Client;
 import io.etcd.jetcd.ClientBuilder;
 import io.microsphere.etcd.spring.cloud.client.EtcdClientProperties;
 import io.microsphere.etcd.spring.cloud.client.discovery.EtcdDiscoveryClient;
+import io.microsphere.etcd.spring.cloud.client.discovery.EtcdReactiveDiscoveryClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.client.ConditionalOnBlockingDiscoveryEnabled;
+import org.springframework.cloud.client.ConditionalOnDiscoveryEnabled;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import java.util.Set;
 
@@ -35,6 +39,7 @@ import java.util.Set;
  * @see EtcdDiscoveryClient
  * @since 1.0.0
  */
+@Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(EtcdClientProperties.class)
 public class EtcdDiscoveryAutoConfiguration {
 
@@ -47,10 +52,33 @@ public class EtcdDiscoveryAutoConfiguration {
         return clientBuilder.build();
     }
 
-    @ConditionalOnMissingBean
-    @Bean
-    public EtcdDiscoveryClient etcdDiscoveryClient(Client client, EtcdClientProperties etcdClientProperties
-            , ObjectMapper objectMapper) {
-        return new EtcdDiscoveryClient(client, etcdClientProperties, objectMapper);
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnDiscoveryEnabled
+    @ConditionalOnBlockingDiscoveryEnabled
+    protected static class EtcdDiscoveryClientConfiguration {
+
+        @ConditionalOnMissingBean
+        @Bean
+        public EtcdDiscoveryClient etcdDiscoveryClient(Client client, EtcdClientProperties etcdClientProperties
+                , ObjectMapper objectMapper) {
+            return new EtcdDiscoveryClient(client, etcdClientProperties, objectMapper);
+        }
+    }
+
+
+
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnDiscoveryEnabled
+    @ConditionalOnBlockingDiscoveryEnabled
+    protected static class EtcdReactiveDiscoveryClientConfiguration {
+
+        @ConditionalOnMissingBean
+        @Bean
+        public EtcdReactiveDiscoveryClient etcdDiscoveryClient(Client client, EtcdClientProperties etcdClientProperties
+                , ObjectMapper objectMapper) {
+            return new EtcdReactiveDiscoveryClient(client, etcdClientProperties, objectMapper);
+        }
     }
 }

--- a/microsphere-etcd-spring-cloud/src/main/java/io/microsphere/etcd/spring/cloud/client/util/KVClientUtils.java
+++ b/microsphere-etcd-spring-cloud/src/main/java/io/microsphere/etcd/spring/cloud/client/util/KVClientUtils.java
@@ -18,6 +18,7 @@ package io.microsphere.etcd.spring.cloud.client.util;
 
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.KV;
+import io.microsphere.util.StringUtils;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -45,6 +46,11 @@ public class KVClientUtils {
 
     public static String buildServicePath(String rootPath, String serviceId) {
         return rootPath + "/" + serviceId + "/";
+    }
+
+    public static String buildInstanceId(String rootPath, String serviceId, String serviceInstancePath) {
+        String servicePath = buildServicePath(rootPath, serviceId);
+        return StringUtils.substringAfter(serviceInstancePath, servicePath);
     }
 
     public static String resolveServiceId(String serviceInstancePath, String rootPath) {


### PR DESCRIPTION
Complements the ReactiveDiscoveryClient implementation in microsphere-etcd-spring-cloud;
Separating cache-related code into ServiceInstancesCache.